### PR TITLE
ACM: Skip time comparisons

### DIFF
--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -3,7 +3,7 @@ import base64
 
 from moto.core.responses import BaseResponse
 from typing import Dict, List, Tuple, Union
-from .models import acm_backends, AWSCertificateManagerBackend, datetime_to_epoch
+from .models import acm_backends, AWSCertificateManagerBackend
 from .exceptions import AWSValidationException
 
 
@@ -130,26 +130,7 @@ class AWSCertificateManagerResponse(BaseResponse):
         certs = []
         statuses = self._get_param("CertificateStatuses")
         for cert_bundle in self.acm_backend.get_certificates_list(statuses):
-            cert = {
-                "CertificateArn": cert_bundle.arn,
-                "DomainName": cert_bundle.common_name,
-                "Status": cert_bundle.status,
-                "Type": cert_bundle.type,
-                "NotBefore": datetime_to_epoch(cert_bundle._cert.not_valid_before),
-                "NotAfter": datetime_to_epoch(cert_bundle._cert.not_valid_after),
-                "CreatedAt": datetime_to_epoch(cert_bundle.created_at),
-                "KeyAlgorithm": cert_bundle.describe()["Certificate"]["KeyAlgorithm"],
-                "RenewalEligibility": cert_bundle.describe()["Certificate"][
-                    "RenewalEligibility"
-                ],
-            }
-
-            if cert_bundle.type == "IMPORTED":
-                cert["ImportedAt"] = datetime_to_epoch(cert_bundle.created_at)
-            elif cert_bundle.type == "AMAZON_ISSUED":
-                cert["IssuedAt"] = datetime_to_epoch(cert_bundle.created_at)
-
-            certs.append(cert)
+            certs.append(cert_bundle.describe()["Certificate"])
 
         result = {"CertificateSummaryList": certs}
         return json.dumps(result)


### PR DESCRIPTION
Hey @jfagoagas, I looked at the list_certificates a bit more in depth, and I think this is the best approach.

All the logic for describing certificates is already present in the `describe()`-method, so we might as well re-use that.

As for the timezones:
Most services send back ISO-8601 formatted dates, but AWS does send back epochs for ACM, so we're stuck using the same format. 
The downside of epochs is of-course that it's not possible for them to contain timezone-information, so instead of figuring out how AWS solves that problem, I opted for the lazy approach - just verify that the date exists, but no direct comparisons.